### PR TITLE
Optimise loop by removing string reversal

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,19 +4,31 @@
 pub fn valid(number: &str) -> bool {
     let mut checksum = 0;
 
-    let mut iter = number.chars().rev();
-    loop {
+    let mut iter = number.chars();
+
+    // If the number contains an odd number of digits then 
+    // the first digit is an 'odd' digit
+    if number.len() % 2 == 1 {
         match iter.next() {
             Some(c) => checksum += checksum_modifier_odd(c),
-            None => break,
+            None => return true, // Never reached
         }
+    }
+
+    // Iterate the rest of the number in pairs starting 
+    // with an 'even' number 
+    loop {
         match iter.next() {
             Some(c) => checksum += checksum_modifier_even(c),
             None => break,
         }
+        match iter.next() {
+            Some(c) => checksum += checksum_modifier_odd(c),
+            None => break,
+        }
     }
 
-    return checksum%10 == 0
+    checksum % 10 == 0
 }
 
 fn checksum_modifier_odd(c: char) -> u32 {


### PR DESCRIPTION
The previous version reversed the string and then iterated through the digits (in effect from right to left of the original string).  Reversing the iterator is slow (particularly on longer strings) so this version removes the reversal and iterates from left to right. However, to do this correctly it must test whether the string is an odd number of digits in length and deal with the first digit if the string is an odd length.

Benchmarking using the number `99999999999999999999999999999999999999999999999999999999999999999997` takes ~30ns using this version compared to ~44ns using the previous version (on an 8-core i9 iMac). Benchmarking using 16 digit "credit card" numbers does not show a measurable difference.

This optimisation is the result of a mental exercise to see if I could get a speed increase.  I learnt some interesting things about Rust. As usual what you would assume to be intuitively quicker is not necessarily the case.

Feel free to adopt these changes or not as you see fit. 

(I didn't bump the version number. I leave that to you, if you do merge the changes)